### PR TITLE
(test/server-socket) move modules to npm production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "reactify": "^1.1.1",
     "socket.io": "^1.3.5",
     "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.2.3"
-  },
-  "devDependencies": {
+    "watchify": "^3.2.3", 
     "gulp-mocha": "^2.1.3",
     "should": "^7.0.2",
     "socket.io-client": "^1.3.5"


### PR DESCRIPTION
Moved socket.io-client, gulp-mocha and should modules to production dependencies
